### PR TITLE
fixed bug when defaultPropertyValues not initiated using -initWithJSONDictionary:

### DIFF
--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -100,7 +100,7 @@ static NSString *MCTypeStringFromPropertyKey(Class class, NSString *key) {
 }
 
 - (instancetype)initWithJSONDictionary:(NSDictionary *)dictionary {
-	self = [super init];
+	self = [self init];
 	if (self) {
 		[self mc_setValuesFromJSONDictionary:dictionary inRealm:nil];
 	}


### PR DESCRIPTION
[self init] should be called instead of superclass, to initiate values from : + (NSDictionary *)defaultPropertyValues
