### PR TITLE
Allow inbound transformers for property with specific classes.

### DIFF
--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -156,7 +156,15 @@ static NSString *MCTypeStringFromPropertyKey(Class class, NSString *key) {
 					continue;
 				}
 
-				value = [propertyClass mc_createObjectFromJSONDictionary:value];
+                if ([value isKindOfClass:[NSDictionary class]]) {
+                    value = [propertyClass mc_createObjectFromJSONDictionary:value];
+                } else {
+                    NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
+                    
+                    if (transformer) {
+                        value = [transformer transformedValue:value];
+                    }
+                }
 			}
 			else if ([propertyClass isSubclassOfClass:[RLMArray class]]) {
                 RLMProperty *property = [self mc_propertyForPropertyKey:objectKeyPath];


### PR DESCRIPTION
**I have class BGRoom with property**

`@property (strong, nonatomic) BGChannel *channel;`

And my JSON looks like this
`{
    ...
    "roomChannel": "42"
    ...
}`

I write JSON mapping 
`return @{
             ....
             @"roomChannel": @"channel",
             ....
             };`

I want to write transformer for channel property like this

```
@implementation StringChannelTransformer

- (id)transformedValue:(NSString*)value {
    if (!value) return nil;
    return [BGChannel objectForPrimaryKey:value];
}
```
