### PR TITLE
Add base implementation for primary key binding.

### DIFF
--- a/Realm+JSON/MCJSONPrimaryKeyTransformer.h
+++ b/Realm+JSON/MCJSONPrimaryKeyTransformer.h
@@ -1,0 +1,18 @@
+//
+//  MCJSONPrimaryKeyTransformer.h
+//  RealmJSON
+//
+//  Created by Anton Gaenko on 14.12.14.
+//  Copyright (c) 2014 Anton Gaenko. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Realm/Realm.h>
+
+@interface MCJSONPrimaryKeyTransformer : NSValueTransformer
+
+// it should be RLMObject subclass
++ (instancetype)valueTransformerWithRealmClass:(Class)realmClass;
+- (instancetype)initWithRealmClass:(Class)realmClass;
+
+@end

--- a/Realm+JSON/MCJSONPrimaryKeyTransformer.m
+++ b/Realm+JSON/MCJSONPrimaryKeyTransformer.m
@@ -1,0 +1,46 @@
+//
+//  MCJSONPrimaryKeyTransformer.m
+//  RealmJSON
+//
+//  Created by Anton Gaenko on 14.12.14.
+//  Copyright (c) 2014 Anton Gaenko. All rights reserved.
+//
+
+#import "MCJSONPrimaryKeyTransformer.h"
+
+@interface MCJSONPrimaryKeyTransformer ()
+
+@property (nonatomic, assign) Class realmClassToMap;
+
+@end
+
+@implementation MCJSONPrimaryKeyTransformer
+
++ (instancetype)valueTransformerWithRealmClass:(Class)realmClass {
+    return [[self alloc] initWithRealmClass:realmClass];
+}
+
+- (instancetype)initWithRealmClass:(Class)realmClass {
+    self = [super init];
+    if (self) {
+        // it should be RLMObject subclass
+        BOOL isRlmObjectSubclass  = [realmClass respondsToSelector:@selector(isSubclassOfClass:)] &&
+                                    [realmClass isSubclassOfClass:[RLMObject class]];
+        
+        if (isRlmObjectSubclass) {
+            self.realmClassToMap = realmClass;
+        }
+        
+    }
+    return self;
+}
+
+- (id)transformedValue:(NSString*)value {
+    if (value && self.realmClassToMap) {
+        return [self.realmClassToMap performSelector:@selector(objectForPrimaryKey:) withObject:value];
+    }
+    
+    return nil;
+}
+
+@end


### PR DESCRIPTION
Example usage

```
@implementation BGRoom (JSON)

+ (NSValueTransformer *)channelJSONTransformer
{
    return [[MCJSONPrimaryKeyTransformer alloc] initWithRealmClass:[BGChannel class]];
}

@end
```
