### PR TITLE
Added handling for empty dictionaries to be treated as a null.

### DIFF
--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -152,7 +152,7 @@ static NSString *MCTypeStringFromPropertyKey(Class class, NSString *key) {
 			Class propertyClass = [modelClass mc_classForPropertyKey:objectKeyPath];
 
 			if ([propertyClass isSubclassOfClass:[RLMObject class]]) {
-				if (!value || [value isEqual:[NSNull null]]) {
+				if (!value || [value isEqual:[NSNull null]] || [value count] == 0) {
 					continue;
 				}
 


### PR DESCRIPTION
There doesn't seem to be a JSON standard for returning empty dictionaries vs just null. When an API returns an empty dictionary, Realm treats it as a regular object and just fills it with default values - creating a relationship that shouldn't be there. By checking if the count of the dictionary is 0, we avoid this unnecessary relationship. 
