### PR TITLE
OS X deployment target to podspec

### DIFF
--- a/Realm+JSON.podspec
+++ b/Realm+JSON.podspec
@@ -2,6 +2,7 @@ Pod::Spec.new do |s|
   s.name     = 'Realm+JSON'
   s.version  = '0.2.5'
   s.ios.deployment_target   = '7.0'
+  s.osx.deployment_target = '10.8'
   s.license  = { :type => 'MIT', :file => 'LICENSE' }
   s.summary  = 'A concise Mantle-like way of working with Realm and JSON.'
   s.homepage = 'https://github.com/matthewcheok/Realm-JSON'


### PR DESCRIPTION
Admittedly, I've only tested `JSONDictionary` and `JSONArray` methods. They work and it has no problems compiling  ¯\\_(ツ)_/¯ Also not really sure if `10.8` is a safe minimum. I'm running `10.10`, but I gathered it can always be changed to higher later if somebody has problems.