### PR TITLE
Make it build for Realm 0.91

### DIFF
--- a/Realm+JSON/RLMObject+Copying.m
+++ b/Realm+JSON/RLMObject+Copying.m
@@ -8,6 +8,9 @@
 
 #import "RLMObject+Copying.h"
 
+#import <Realm/RLMProperty.h>
+#import <Realm/RLMObjectSchema.h>
+
 @implementation RLMObject (Copying)
 
 - (instancetype)shallowCopy {

--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -8,6 +8,9 @@
 
 #import "RLMObject+JSON.h"
 
+#import <Realm/RLMProperty.h>
+#import <Realm/RLMObjectSchema.h>
+
 // RLMSchema private interface
 @interface RLMSchema ()
 // class for string


### PR DESCRIPTION
It seems that `RLMProperty.h` and `RLMObjectSchema.h` must be directly imported now. 