### PR TITLE
Transform values before trying anything else

### DIFF
--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -159,66 +159,63 @@ static NSInteger const kCreateBatchSize = 100;
 + (id)mc_createObjectFromJSONDictionary:(NSDictionary *)dictionary {
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
 	NSDictionary *mapping = [[self class] mc_inboundMapping];
-    
+
 	for (NSString *dictionaryKeyPath in mapping) {
 		NSString *objectKeyPath = mapping[dictionaryKeyPath];
 
 		id value = [dictionary valueForKeyPath:dictionaryKeyPath];
+
 		if (value) {
-            
 			Class propertyClass = [[self class] mc_classForPropertyKey:objectKeyPath];
 
-			if ([propertyClass isSubclassOfClass:[RLMObject class]]) {
+			NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
+			if (transformer) {
+				value = [transformer transformedValue:value];
+			}
+			else if ([propertyClass isSubclassOfClass:[RLMObject class]]) {
 				if (!value || [value isEqual:[NSNull null]]) {
 					continue;
 				}
 
-                if ([value isKindOfClass:[NSDictionary class]]) {
-                    value = [propertyClass mc_createObjectFromJSONDictionary:value];
-                } else {
-                    NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
-                    
-                    if (transformer) {
-                        value = [transformer transformedValue:value];
-                    }
-                }
-			}
-			else if ([propertyClass isSubclassOfClass:[RLMArray class]]) {
-                RLMProperty *property = [self mc_propertyForPropertyKey:objectKeyPath];
-                Class elementClass = [RLMSchema classForString: property.objectClassName];
-                
-                NSMutableArray *array = [NSMutableArray array];
-                for (id item in(NSArray*) value) {
-                    [array addObject:[elementClass mc_createObjectFromJSONDictionary:item]];
-                }
-                value = [array copy];
-			}
-			else {
-				NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
+				if ([value isKindOfClass:[NSDictionary class]]) {
+					value = [propertyClass mc_createObjectFromJSONDictionary:value];
+				} else {
+					NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
 
-				if (transformer) {
-					value = [transformer transformedValue:value];
+					if (transformer) {
+						value = [transformer transformedValue:value];
+					}
 				}
 			}
-            
-            if ([objectKeyPath isEqualToString:@"self"]) {
-                return value;
-            }
-            
-            NSArray *keyPathComponents = [objectKeyPath componentsSeparatedByString:@"."];
-            id currentDictionary = result;
-            for (NSString *component in keyPathComponents) {
-                if ([currentDictionary valueForKey:component] == nil) {
-                    [currentDictionary setValue:[NSMutableDictionary dictionary] forKey:component];
-                }
-                currentDictionary = [currentDictionary valueForKey:component];
-            }
+			else if ([propertyClass isSubclassOfClass:[RLMArray class]]) {
+				RLMProperty *property = [self mc_propertyForPropertyKey:objectKeyPath];
+				Class elementClass = [RLMSchema classForString: property.objectClassName];
+
+				NSMutableArray *array = [NSMutableArray array];
+				for (id item in(NSArray*) value) {
+					[array addObject:[elementClass mc_createObjectFromJSONDictionary:item]];
+				}
+				value = [array copy];
+			}
+
+			if ([objectKeyPath isEqualToString:@"self"]) {
+				return value;
+			}
+
+			NSArray *keyPathComponents = [objectKeyPath componentsSeparatedByString:@"."];
+			id currentDictionary = result;
+			for (NSString *component in keyPathComponents) {
+				if ([currentDictionary valueForKey:component] == nil) {
+					[currentDictionary setValue:[NSMutableDictionary dictionary] forKey:component];
+				}
+				currentDictionary = [currentDictionary valueForKey:component];
+			}
 
 			[result setValue:value forKeyPath:objectKeyPath];
 		}
 	}
-    
-    return [result copy];
+
+	return [result copy];
 }
 
 - (id)mc_createJSONDictionary {
@@ -232,7 +229,11 @@ static NSInteger const kCreateBatchSize = 100;
 		if (value) {
 			Class propertyClass = [[self class] mc_classForPropertyKey:objectKeyPath];
 
-			if ([propertyClass isSubclassOfClass:[RLMObject class]]) {
+			NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
+			if (transformer) {
+				value = [transformer reverseTransformedValue:value];
+			}
+			else if ([propertyClass isSubclassOfClass:[RLMObject class]]) {
 				value = [value mc_createJSONDictionary];
 			}
 			else if ([propertyClass isSubclassOfClass:[RLMArray class]]) {
@@ -241,13 +242,6 @@ static NSInteger const kCreateBatchSize = 100;
 					[array addObject:[item mc_createJSONDictionary]];
 				}
 				value = [array copy];
-			}
-			else {
-				NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
-
-				if (transformer) {
-					value = [transformer reverseTransformedValue:value];
-				}
 			}
 
 			if ([dictionaryKeyPath isEqualToString:@"self"]) {

--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -61,7 +61,7 @@ static NSInteger const kCreateBatchSize = 100;
 + (NSArray *)createOrUpdateInRealm:(RLMRealm *)realm withJSONArray:(NSArray *)array {
     NSInteger count = array.count;
     NSMutableArray *result = [NSMutableArray array];
-    
+
     for (NSInteger index=0; index*kCreateBatchSize<count; index++) {
         NSInteger size = MIN(kCreateBatchSize, count-index*kCreateBatchSize);
         @autoreleasepool {
@@ -72,7 +72,7 @@ static NSInteger const kCreateBatchSize = 100;
             }
         }
     }
-    
+
     return [result copy];
 }
 
@@ -179,12 +179,6 @@ static NSInteger const kCreateBatchSize = 100;
 
 				if ([value isKindOfClass:[NSDictionary class]]) {
 					value = [propertyClass mc_createObjectFromJSONDictionary:value];
-				} else {
-					NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
-
-					if (transformer) {
-						value = [transformer transformedValue:value];
-					}
 				}
 			}
 			else if ([propertyClass isSubclassOfClass:[RLMArray class]]) {
@@ -268,7 +262,7 @@ static NSInteger const kCreateBatchSize = 100;
 
 + (NSDictionary *)mc_defaultInboundMapping {
     RLMObjectSchema *schema = [self sharedSchema];
-    
+
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
     for (RLMProperty *property in schema.properties) {
         result[[property.name camelToSnakeCase]] = property.name;
@@ -280,11 +274,11 @@ static NSInteger const kCreateBatchSize = 100;
 
 + (NSDictionary *)mc_defaultOutboundMapping {
     RLMObjectSchema *schema = [self sharedSchema];
-    
+
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
     for (RLMProperty *property in schema.properties) {
         result[property.name] = [property.name camelToSnakeCase];
-        
+
     }
 
 	return [result copy];


### PR DESCRIPTION
Allows on-the-fly transforming JSON arrays containing NSStrings to RLMObject sub-classes. For this to work, we must check for transforms before anything else.

If we have a JSON array of strings, we can't transform them if the property type is RLMArray, as this gets processed first in the current codebase, and will crash (we'll eventually call ```mc_createObjectFromJSONDictionary``` with an NSString instead of an NSDictionary). 

This pull request changes the order we try to process JSON fields from:

1. Dictionary
2. RLMArray
3. Transformer 

to 

1. Transformer
2. Dictionary
3. RLMArray

This makes sense as we should trust that the developer knows hows to transform the values if a transformer is set.