### PR TITLE
Fix incorrect inner loop when batching createOrUpdateInRealm:withJSONDictionary: calls

### DIFF
--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -65,8 +65,8 @@ static NSInteger const kCreateBatchSize = 100;
     for (NSInteger index=0; index*kCreateBatchSize<count; index++) {
         NSInteger size = MIN(kCreateBatchSize, count-index*kCreateBatchSize);
         @autoreleasepool {
-            for (NSInteger subIndex=index*kCreateBatchSize; subIndex<size; subIndex++) {
-                NSDictionary *dictionary = array[subIndex];
+            for (NSInteger subIndex=0; subIndex<size; subIndex++) {
+                NSDictionary *dictionary = array[index*kCreateBatchSize+subIndex];
                 id object = [self createOrUpdateInRealm:realm withJSONDictionary:dictionary];
                 [result addObject:object];
             }


### PR DESCRIPTION
Current implementation incorrectly stops running the inner loop after the first 100 objects, since `index*kCreateBatchSize < size` is always false after the first run of the outer loop.

With some logging, this is what I'm seeing:
>array size: 456
>index: 0, subIndex: 0, size: 100
>index: 1, subIndex: 100, size: 100
>index: 2, subIndex: 200, size: 100
>index: 3, subIndex: 300, size: 100
>index: 4, subIndex: 400, size: 56
>total calls to createOrUpdateInRealm:withJSONDictionary: was 100

As well as confirming with `[RLMRealm allObjects]` giving me no more than 100 objects.
