### PR TITLE
Replaced [self class] for getting objects classes in Copying Category

### DIFF
--- a/Realm+JSON/RLMObject+Copying.m
+++ b/Realm+JSON/RLMObject+Copying.m
@@ -20,7 +20,7 @@
 @implementation RLMObject (Copying)
 
 - (instancetype)shallowCopy {
-    id object = [[[self class] alloc] init];
+    id object = [[NSClassFromString(self.objectSchema.className) alloc] init];
     [object mergePropertiesFromObject:self];
     
     return object;
@@ -43,7 +43,7 @@
 }
 
 - (instancetype)deepCopy {
-    RLMObject *object = [[[self class] alloc] init];
+    RLMObject *object = [[NSClassFromString(self.objectSchema.className) alloc] init];
     
     for (RLMProperty *property in self.objectSchema.properties) {
 


### PR DESCRIPTION
Realm uses custom subclasses of your models for different situations, for example if you create a model called `Dog`, you may get classes like this in a `RLMResult`: 

`RLMAccessor_V0_Dog`

Or something like this after an `init` (When the object is not associated to any realm):

`RLMStandalone_Dog`

So using `[self class]` for creating the copy may end in unexpected behaviors, as we may end using one of these custom subclasses. I think it's safer to use `self.objectSchema.className` for getting the class. 

This was suddenly producing `Object has been deleted or invalidated` exceptions for my code for the latest Realm version (only in the simulator, but is still dangerous). 