### PR TITLE
Allow NSNumber to be used instead of string for conversion to dates.

### DIFF
--- a/Realm+JSON.podspec
+++ b/Realm+JSON.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Realm+JSON'
-  s.version  = '0.2.7'
+  s.version  = '0.2.8'
   s.ios.deployment_target   = '7.0'
   s.osx.deployment_target = '10.9'
   s.license  = { :type => 'MIT', :file => 'LICENSE' }

--- a/Realm+JSON.podspec
+++ b/Realm+JSON.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Realm+JSON'
-  s.version  = '0.2.8'
+  s.version  = '0.2.9'
   s.ios.deployment_target   = '7.0'
   s.osx.deployment_target = '10.9'
   s.license  = { :type => 'MIT', :file => 'LICENSE' }

--- a/Realm+JSON.podspec
+++ b/Realm+JSON.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Realm+JSON/*.{h,m}'
   s.public_header_files = 'Realm+JSON/*.h'
 
-  s.dependency 'Realm', '~> 0.91'
+  s.dependency 'Realm', '~> 0.92'
 end

--- a/Realm+JSON.podspec
+++ b/Realm+JSON.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Realm+JSON'
-  s.version  = '0.2.9'
+  s.version  = '0.2.10'
   s.ios.deployment_target   = '7.0'
   s.osx.deployment_target = '10.9'
   s.license  = { :type => 'MIT', :file => 'LICENSE' }

--- a/Realm+JSON/MCJSONDateTransformer.m
+++ b/Realm+JSON/MCJSONDateTransformer.m
@@ -34,41 +34,45 @@ static NSString *const kDateFormatDateOnly = @"yyyy-MM-dd";
 }
 
 - (instancetype)initWithDateStyle:(MCJSONDateTransformerStyle)style {
-	self = [super init];
-	if (self) {
-		self.formatter = [[NSDateFormatter alloc] init];
+    self = [super init];
+    if (self) {
+        self.formatter = [[NSDateFormatter alloc] init];
         self.formatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
-
-		switch (style) {
-			case MCJSONDateTransformerStyleDateOnly:
-				self.formatter.dateFormat = kDateFormatDateOnly;
-				break;
+        
+        switch (style) {
+            case MCJSONDateTransformerStyleDateOnly:
+                self.formatter.dateFormat = kDateFormatDateOnly;
+                break;
             case MCJSONDateTransformerStyleDateTimeMillisecond:
                 self.formatter.dateFormat = kDateFormatDateTimeMillisecond;
                 break;
                 
-			default:
-				self.formatter.dateFormat = kDateFormatDateTime;
-				break;
-		}
-	}
-	return self;
+            default:
+                self.formatter.dateFormat = kDateFormatDateTime;
+                break;
+        }
+    }
+    return self;
 }
 
 + (Class)transformedValueClass {
-	return [NSDate class];
+    return [NSDate class];
 }
 
 + (BOOL)allowsReverseTransformation {
-	return YES;
+    return YES;
 }
 
 - (id)transformedValue:(id)value {
-	return [self.formatter dateFromString:value];
+    if([value isKindOfClass:[NSString class]]) {
+        return [self.formatter dateFromString:value];
+    } else if ([value isKindOfClass:[NSNumber class]]){
+        return [NSDate dateWithTimeIntervalSince1970:[value integerValue]];
+    }
 }
 
 - (id)reverseTransformedValue:(id)value {
-	return [self.formatter stringFromDate:value];
+    return [self.formatter stringFromDate:value];
 }
 
 @end

--- a/Realm+JSON/MCJSONNonNullStringTransformer.h
+++ b/Realm+JSON/MCJSONNonNullStringTransformer.h
@@ -1,0 +1,15 @@
+//
+//  MCJSONNonNullStringTransformer.h
+//  Pods
+//
+//  Created by Matthew Cheok on 23/5/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface MCJSONNonNullStringTransformer : NSValueTransformer
+
++ (instancetype)valueTransformer;
+
+@end

--- a/Realm+JSON/MCJSONNonNullStringTransformer.m
+++ b/Realm+JSON/MCJSONNonNullStringTransformer.m
@@ -1,0 +1,38 @@
+//
+//  MCJSONNonNullStringTransformer.m
+//  Pods
+//
+//  Created by Matthew Cheok on 23/5/15.
+//
+//
+
+#import "MCJSONNonNullStringTransformer.h"
+
+@implementation MCJSONNonNullStringTransformer
+
++ (instancetype)valueTransformer {
+	return [[self alloc] init];
+}
+
++ (Class)transformedValueClass {
+	return [NSString class];
+}
+
++ (BOOL)allowsReverseTransformation {
+	return YES;
+}
+
+- (id)transformedValue:(id)value {
+	if (value && ![value isKindOfClass:[NSNull class]]) {
+		return value;
+	}
+	else {
+		return @"";
+	}
+}
+
+- (id)reverseTransformedValue:(id)value {
+	return value;
+}
+
+@end

--- a/Realm+JSON/RLMObject+Copying.m
+++ b/Realm+JSON/RLMObject+Copying.m
@@ -20,7 +20,7 @@
 @implementation RLMObject (Copying)
 
 - (instancetype)shallowCopy {
-    id object = [[[self class] alloc] init];
+    id object = [[NSClassFromString(self.objectSchema.className) alloc] init];
     [object mergePropertiesFromObject:self];
     
     return object;
@@ -43,7 +43,7 @@
 }
 
 - (instancetype)deepCopy {
-    RLMObject *object = [[[self class] alloc] init];
+    RLMObject *object = [[NSClassFromString(self.objectSchema.className) alloc] init];
     
     for (RLMProperty *property in self.objectSchema.properties) {
 

--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -65,8 +65,8 @@ static NSInteger const kCreateBatchSize = 100;
     for (NSInteger index=0; index*kCreateBatchSize<count; index++) {
         NSInteger size = MIN(kCreateBatchSize, count-index*kCreateBatchSize);
         @autoreleasepool {
-            for (NSInteger subIndex=index*kCreateBatchSize; subIndex<size; subIndex++) {
-                NSDictionary *dictionary = array[subIndex];
+            for (NSInteger subIndex=0; subIndex<size; subIndex++) {
+                NSDictionary *dictionary = array[index*kCreateBatchSize+subIndex];
                 id object = [self createOrUpdateInRealm:realm withJSONDictionary:dictionary];
                 [result addObject:object];
             }

--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -77,7 +77,7 @@ static NSInteger const kCreateBatchSize = 100;
 }
 
 + (instancetype)createOrUpdateInRealm:(RLMRealm *)realm withJSONDictionary:(NSDictionary *)dictionary {
-	return [self createOrUpdateInRealm:realm withObject:[self mc_createObjectFromJSONDictionary:dictionary]];
+	return [self createOrUpdateInRealm:realm withValue:[self mc_createObjectFromJSONDictionary:dictionary]];
 }
 
 + (instancetype)objectInRealm:(RLMRealm *)realm withPrimaryKeyValue:(id)primaryKeyValue {
@@ -103,7 +103,7 @@ static NSInteger const kCreateBatchSize = 100;
 }
 
 - (instancetype)initWithJSONDictionary:(NSDictionary *)dictionary {
-	self = [self initWithObject:[[self class] mc_createObjectFromJSONDictionary:dictionary]];
+	self = [self initWithValue:[[self class] mc_createObjectFromJSONDictionary:dictionary]];
 	if (self) {
 	}
 	return self;

--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -159,66 +159,63 @@ static NSInteger const kCreateBatchSize = 100;
 + (id)mc_createObjectFromJSONDictionary:(NSDictionary *)dictionary {
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
 	NSDictionary *mapping = [[self class] mc_inboundMapping];
-    
+
 	for (NSString *dictionaryKeyPath in mapping) {
 		NSString *objectKeyPath = mapping[dictionaryKeyPath];
 
 		id value = [dictionary valueForKeyPath:dictionaryKeyPath];
+
 		if (value) {
-            
 			Class propertyClass = [[self class] mc_classForPropertyKey:objectKeyPath];
 
-			if ([propertyClass isSubclassOfClass:[RLMObject class]]) {
+			NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
+			if (transformer) {
+				value = [transformer transformedValue:value];
+			}
+			else if ([propertyClass isSubclassOfClass:[RLMObject class]]) {
 				if (!value || [value isEqual:[NSNull null]]) {
 					continue;
 				}
 
-                if ([value isKindOfClass:[NSDictionary class]]) {
-                    value = [propertyClass mc_createObjectFromJSONDictionary:value];
-                } else {
-                    NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
-                    
-                    if (transformer) {
-                        value = [transformer transformedValue:value];
-                    }
-                }
-			}
-			else if ([propertyClass isSubclassOfClass:[RLMArray class]]) {
-                RLMProperty *property = [self mc_propertyForPropertyKey:objectKeyPath];
-                Class elementClass = [RLMSchema classForString: property.objectClassName];
-                
-                NSMutableArray *array = [NSMutableArray array];
-                for (id item in(NSArray*) value) {
-                    [array addObject:[elementClass mc_createObjectFromJSONDictionary:item]];
-                }
-                value = [array copy];
-			}
-			else {
-				NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
+				if ([value isKindOfClass:[NSDictionary class]]) {
+					value = [propertyClass mc_createObjectFromJSONDictionary:value];
+				} else {
+					NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
 
-				if (transformer) {
-					value = [transformer transformedValue:value];
+					if (transformer) {
+						value = [transformer transformedValue:value];
+					}
 				}
 			}
-            
-            if ([objectKeyPath isEqualToString:@"self"]) {
-                return value;
-            }
-            
-            NSArray *keyPathComponents = [objectKeyPath componentsSeparatedByString:@"."];
-            id currentDictionary = result;
-            for (NSString *component in keyPathComponents) {
-                if ([currentDictionary valueForKey:component] == nil) {
-                    [currentDictionary setValue:[NSMutableDictionary dictionary] forKey:component];
-                }
-                currentDictionary = [currentDictionary valueForKey:component];
-            }
+			else if ([propertyClass isSubclassOfClass:[RLMArray class]]) {
+				RLMProperty *property = [self mc_propertyForPropertyKey:objectKeyPath];
+				Class elementClass = [RLMSchema classForString: property.objectClassName];
+
+				NSMutableArray *array = [NSMutableArray array];
+				for (id item in(NSArray*) value) {
+					[array addObject:[elementClass mc_createObjectFromJSONDictionary:item]];
+				}
+				value = [array copy];
+			}
+
+			if ([objectKeyPath isEqualToString:@"self"]) {
+				return value;
+			}
+
+			NSArray *keyPathComponents = [objectKeyPath componentsSeparatedByString:@"."];
+			id currentDictionary = result;
+			for (NSString *component in keyPathComponents) {
+				if ([currentDictionary valueForKey:component] == nil) {
+					[currentDictionary setValue:[NSMutableDictionary dictionary] forKey:component];
+				}
+				currentDictionary = [currentDictionary valueForKey:component];
+			}
 
 			[result setValue:value forKeyPath:objectKeyPath];
 		}
 	}
-    
-    return [result copy];
+
+	return [result copy];
 }
 
 - (id)mc_createJSONDictionary {
@@ -232,7 +229,11 @@ static NSInteger const kCreateBatchSize = 100;
 		if (value) {
 			Class propertyClass = [[self class] mc_classForPropertyKey:objectKeyPath];
 
-			if ([propertyClass isSubclassOfClass:[RLMObject class]]) {
+			NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
+			if (transformer) {
+				value = [transformer reverseTransformedValue:value];
+			}
+			else if ([propertyClass isSubclassOfClass:[RLMObject class]]) {
 				value = [value mc_createJSONDictionary];
 			}
 			else if ([propertyClass isSubclassOfClass:[RLMArray class]]) {
@@ -241,13 +242,6 @@ static NSInteger const kCreateBatchSize = 100;
 					[array addObject:[item mc_createJSONDictionary]];
 				}
 				value = [array copy];
-			}
-			else {
-				NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
-
-				if (transformer) {
-					value = [transformer reverseTransformedValue:value];
-				}
 			}
 
 			if ([dictionaryKeyPath isEqualToString:@"self"]) {

--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -61,7 +61,7 @@ static NSInteger const kCreateBatchSize = 100;
 + (NSArray *)createOrUpdateInRealm:(RLMRealm *)realm withJSONArray:(NSArray *)array {
     NSInteger count = array.count;
     NSMutableArray *result = [NSMutableArray array];
-    
+
     for (NSInteger index=0; index*kCreateBatchSize<count; index++) {
         NSInteger size = MIN(kCreateBatchSize, count-index*kCreateBatchSize);
         @autoreleasepool {
@@ -72,7 +72,7 @@ static NSInteger const kCreateBatchSize = 100;
             }
         }
     }
-    
+
     return [result copy];
 }
 
@@ -179,12 +179,6 @@ static NSInteger const kCreateBatchSize = 100;
 
 				if ([value isKindOfClass:[NSDictionary class]]) {
 					value = [propertyClass mc_createObjectFromJSONDictionary:value];
-				} else {
-					NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];
-
-					if (transformer) {
-						value = [transformer transformedValue:value];
-					}
 				}
 			}
 			else if ([propertyClass isSubclassOfClass:[RLMArray class]]) {
@@ -268,7 +262,7 @@ static NSInteger const kCreateBatchSize = 100;
 
 + (NSDictionary *)mc_defaultInboundMapping {
     RLMObjectSchema *schema = [self sharedSchema];
-    
+
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
     for (RLMProperty *property in schema.properties) {
         result[[property.name camelToSnakeCase]] = property.name;
@@ -280,11 +274,11 @@ static NSInteger const kCreateBatchSize = 100;
 
 + (NSDictionary *)mc_defaultOutboundMapping {
     RLMObjectSchema *schema = [self sharedSchema];
-    
+
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
     for (RLMProperty *property in schema.properties) {
         result[property.name] = [property.name camelToSnakeCase];
-        
+
     }
 
 	return [result copy];


### PR DESCRIPTION
As some JSON feeds will not quote their numbers, they get interpreted as NSNumber by NSJSONSerialization.
This is flexible and determines that if it is not an NSString it should
use string value - this is the case for NSNumber and works just fine.

There don't appear to be any negatives, the case of transforming back is left as is, because it isn't inherently clear which case it is unless it has been configured, and that could be done otherwise - but in the case of transforming a value to a date, it'll become apparent once the value is hit and then tried to be transformed.