### PR TITLE
Support unix epoch (NSNumber) as NSDate value source

### DIFF
--- a/Realm+JSON/MCJSONDateTransformer.m
+++ b/Realm+JSON/MCJSONDateTransformer.m
@@ -64,7 +64,13 @@ static NSString *const kDateFormatDateOnly = @"yyyy-MM-dd";
 }
 
 - (id)transformedValue:(id)value {
-	return [self.formatter dateFromString:value];
+    id result = nil;
+    if([value isKindOfClass:[NSString class]]) {
+        result = [self.formatter dateFromString:value];
+    } else if ([value isKindOfClass:[NSNumber class]]){
+        result [NSDate dateWithTimeIntervalSince1970:[value integerValue]];
+    }
+    return result;
 }
 
 - (id)reverseTransformedValue:(id)value {


### PR DESCRIPTION
As some JSON feeds will not quote their numbers, they get interpreted as NSNumber by NSJSONSerialization.

Use NSdate to convert it from time stamp since 1970 if NSNumber detected. failsafe to return nil if its not a string (first checked case)

There don't appear to be any negatives, the case of transforming back is left as is, because it isn't inherently clear which case it is unless it has been configured, and that could be done otherwise - but in the case of transforming a value to a date, it'll become apparent once the value is hit and then tried to be transformed.