### PR TITLE
enable merge of empty primary properties and bumped to 0.2.8

### DIFF
--- a/Realm+JSON.podspec
+++ b/Realm+JSON.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Realm+JSON'
-  s.version  = '0.2.7'
+  s.version  = '0.2.8'
   s.ios.deployment_target   = '7.0'
   s.osx.deployment_target = '10.9'
   s.license  = { :type => 'MIT', :file => 'LICENSE' }

--- a/Realm+JSON/RLMObject+Copying.m
+++ b/Realm+JSON/RLMObject+Copying.m
@@ -34,12 +34,9 @@
     id value;
     id selfValue;
     
-    BOOL (^valueIsEmpty)(id) = ^BOOL(id value) {
-        return (value == nil ||
-                [value isKindOfClass:[NSNull class]] ||
-                ([value respondsToSelector:@selector(length)] &&
-                 [(NSData *) value length] <= 0)
-                );
+    BOOL (^valuesAreEqual)(id, id) = ^BOOL(id value1, id value2) {
+        return ([[NSString stringWithFormat:@"%@", value1]
+                 isEqualToString:[NSString stringWithFormat:@"%@", value2]]);
     };
     
     for (RLMProperty *property in self.objectSchema.properties) {
@@ -51,8 +48,8 @@
             selfValue = [self valueForKeyPath:property.name];
 
             primaryKeyIsEmpty = (property.isPrimary &&
-                                 ![selfValue isEqual:value] &&
-                                 valueIsEmpty(selfValue));
+                                 !valuesAreEqual(value, selfValue)
+                                 );
             
             if (primaryKeyIsEmpty || !property.isPrimary) {
                 [self setValue:value forKeyPath:property.name];
@@ -66,6 +63,7 @@
         }
     }
 }
+
 
 - (instancetype)deepCopy {
     Class class = NSClassFromString([[self class] className]);

--- a/Realm+JSON/RLMObject+Copying.m
+++ b/Realm+JSON/RLMObject+Copying.m
@@ -29,17 +29,40 @@
 }
 
 - (void)mergePropertiesFromObject:(id)object {
+    
+    BOOL primaryKeyIsEmpty;
+    id value;
+    id selfValue;
+    
+    BOOL (^valueIsEmpty)(id) = ^BOOL(id value) {
+        return (value == nil ||
+                [value isKindOfClass:[NSNull class]] ||
+                ([value respondsToSelector:@selector(length)] &&
+                 [(NSData *) value length] <= 0)
+                );
+    };
+    
     for (RLMProperty *property in self.objectSchema.properties) {
-        // assume array
-        if (property.type == RLMPropertyTypeArray) {
+        
+        if (property.type != RLMPropertyTypeArray) {
+
+            // asume data
+            value = [object valueForKeyPath:property.name];
+            selfValue = [self valueForKeyPath:property.name];
+
+            primaryKeyIsEmpty = (property.isPrimary &&
+                                 ![selfValue isEqual:value] &&
+                                 valueIsEmpty(selfValue));
+            
+            if (primaryKeyIsEmpty || !property.isPrimary) {
+                [self setValue:value forKeyPath:property.name];
+            }
+        
+        } else {
+            // asume array
             RLMArray *thisArray = [self valueForKeyPath:property.name];
             RLMArray *thatArray = [object valueForKeyPath:property.name];
             [thisArray addObjects:thatArray];
-        }
-        // assume data
-        else if (!property.isPrimary) {
-            id value = [object valueForKeyPath:property.name];
-            [self setValue:value forKeyPath:property.name];
         }
     }
 }


### PR DESCRIPTION
Primary key value were not merged on empty objects.
Enable merge of primary keys only if the value is empty.

```objective-c

- (void)mergePropertiesFromObject:(id)object {
    
    BOOL primaryKeyIsEmpty;
    id value;
    id selfValue;
    
    BOOL (^valuesAreEqual)(id, id) = ^BOOL(id value1, id value2) {
        return ([[NSString stringWithFormat:@"%@", value1]
                 isEqualToString:[NSString stringWithFormat:@"%@", value2]]);
    };
    
    for (RLMProperty *property in self.objectSchema.properties) {
        
        if (property.type != RLMPropertyTypeArray) {

            // asume data
            value = [object valueForKeyPath:property.name];
            selfValue = [self valueForKeyPath:property.name];

            primaryKeyIsEmpty = (property.isPrimary &&
                                 !valuesAreEqual(value, selfValue)
                                 );
            
            if (primaryKeyIsEmpty || !property.isPrimary) {
                [self setValue:value forKeyPath:property.name];
            }
        
        } else {
            // asume array
            RLMArray *thisArray = [self valueForKeyPath:property.name];
            RLMArray *thatArray = [object valueForKeyPath:property.name];
            [thisArray addObjects:thatArray];
        }
    }
}

```