### PR TITLE
Prevent race condition

### DIFF
--- a/Realm+JSON.podspec
+++ b/Realm+JSON.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Realm+JSON'
-  s.version  = '0.2.11'
+  s.version  = '0.2.12'
   s.ios.deployment_target   = '7.0'
   s.osx.deployment_target = '10.9'
   s.license  = { :type => 'MIT', :file => 'LICENSE' }

--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -287,10 +287,11 @@ static NSInteger const kCreateBatchSize = 100;
 #pragma mark - Convenience Methods
 
 + (NSDictionary *)mc_inboundMapping {
-	static NSMutableDictionary *mappingForClassName = nil;
-	if (!mappingForClassName) {
-		mappingForClassName = [NSMutableDictionary dictionary];
-	}
+    static NSMutableDictionary *mappingForClassName = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        mappingForClassName = [NSMutableDictionary dictionary];
+    });
 
 	NSDictionary *mapping = mappingForClassName[[self className]];
 	if (!mapping) {
@@ -307,10 +308,11 @@ static NSInteger const kCreateBatchSize = 100;
 }
 
 + (NSDictionary *)mc_outboundMapping {
-	static NSMutableDictionary *mappingForClassName = nil;
-	if (!mappingForClassName) {
-		mappingForClassName = [NSMutableDictionary dictionary];
-	}
+    static NSMutableDictionary *mappingForClassName = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        mappingForClassName = [NSMutableDictionary dictionary];
+    });
 
 	NSDictionary *mapping = mappingForClassName[[self className]];
 	if (!mapping) {
@@ -339,10 +341,11 @@ static NSInteger const kCreateBatchSize = 100;
 + (Class)mc_classForPropertyKey:(NSString *)key {
 	NSString *attributes = MCTypeStringFromPropertyKey(self, key);
 	if ([attributes hasPrefix:@"T@"]) {
-		static NSCharacterSet *set = nil;
-		if (!set) {
-			set = [NSCharacterSet characterSetWithCharactersInString:@"\"<"];
-		}
+        static NSCharacterSet *set = nil;
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            set = [NSCharacterSet characterSetWithCharactersInString:@"\"<"];
+        });
 
 		NSString *string;
 		NSScanner *scanner = [NSScanner scannerWithString:attributes];


### PR DESCRIPTION
Allocating static variables inside dispatch_once to prevent race condition and EXC_BAD_ACCESS crahes