### PR TITLE
Outbound mapping per-Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Assume it is a `Vehicle` class which tipe is either `VehicleType.Car` (then has 
         @"maxSpeed": @"maxSpeed";
     };
     if (self.type == VehicleType.Car) {
-        @"licensePlate": @"licensePlate";
+        mapping[@"licensePlate"] = @"licensePlate";
     }
     return mapping.copy;
 }

--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ You should specify the inbound and outbound JSON mapping on your `RLMObject` sub
 
 Leaving out either one of the above will result in a mapping that assumes camelCase for your properties which map to snake_case for the JSON equivalents.
 
+You can specify custom outbound mapping for each object as Realm does not support abstract data type in `RLMArray` (and sometimes back-end does not know how to serialise unknown properties):
+
+Assume it is a `Vehicle` class which tipe is either `VehicleType.Car` (then has `licensePlate`) or `VehicleType.Bike` and has `maxSpeed` property:
+
+```ObjC
+- (NSDictionary *)JSONOutboundMappingDictionary {
+    NSMutableDictionary *mapping = @{
+        @"maxSpeed": @"maxSpeed";
+    };
+    if (self.type == VehicleType.Car) {
+        @"licensePlate": @"licensePlate";
+    }
+    return mapping.copy;
+}
+```
+
 As you can do with Mantle, you can specify `NSValueTransformers` for your properties:
 
     + (NSValueTransformer *)episodeTypeJSONTransformer {

--- a/Realm+JSON.podspec
+++ b/Realm+JSON.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Realm+JSON'
-  s.version  = '0.2.12'
+  s.version  = '0.2.13'
   s.ios.deployment_target   = '7.0'
   s.osx.deployment_target = '10.9'
   s.license  = { :type => 'MIT', :file => 'LICENSE' }

--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -214,7 +214,13 @@ static NSInteger const kCreateBatchSize = 100;
 
 - (id)mc_createJSONDictionary {
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
-	NSDictionary *mapping = [[self class] mc_outboundMapping];
+    NSDictionary *mapping;
+    SEL selector = NSSelectorFromString(@"JSONOutboundMappingDictionary");
+    if ([self respondsToSelector:selector]) {
+        mapping = [self performSelector:selector];
+    } else {
+        mapping = [[self class] mc_outboundMapping];
+    }
 
 	for (NSString *objectKeyPath in mapping) {
 		NSString *dictionaryKeyPath = mapping[objectKeyPath];


### PR DESCRIPTION
Sometimes back-end supports Array of only abstract objects (some properties are required not to be specified), unfortunately Realm does not support abstracted objects in `RLMArray` so JSONOutboundMapping per-Object helps to at least somewhat adopt to abstracted logic. Like:

``` swift
class Vehicle: RLMObject {
    dynamic var maxSpeed: CGFloat = 0
    dynamic var licensePlate = ""

    var JSONOutboundMappingDictionary: NSDictionary {
        var mapping = [
            "maxSpeed" : "maxSpeed"
        ]
        if !licensePlate.isEmpty {
           mapping["licensePlate"] = "licensePlate"
        }
        return mapping
    }
}
```

or so.
