### PR TITLE
Add nil properties to outbound JSON

### DIFF
--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -252,9 +252,9 @@ static NSInteger const kCreateBatchSize = 100;
 			}
 
 			[result setValue:value forKeyPath:dictionaryKeyPath];
-        } else {
-            [result setValue:[NSNull null] forKeyPath:dictionaryKeyPath];
-        }
+		} else {
+			[result setValue:[NSNull null] forKeyPath:dictionaryKeyPath];
+		}
 	}
 
 	return [result copy];

--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -252,7 +252,9 @@ static NSInteger const kCreateBatchSize = 100;
 			}
 
 			[result setValue:value forKeyPath:dictionaryKeyPath];
-		}
+        } else {
+            [result setValue:[NSNull null] forKeyPath:dictionaryKeyPath];
+        }
 	}
 
 	return [result copy];


### PR DESCRIPTION
Include `nil` properties on the outbound JSON. Otherwise updating some value to `nil` won't be noticed, at least for some APIs.