### PR TITLE
Mutex lock static variables

### DIFF
--- a/Realm+JSON.podspec
+++ b/Realm+JSON.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Realm+JSON'
-  s.version  = '0.2.12'
+  s.version  = '0.2.13'
   s.ios.deployment_target     = '7.0'
   s.osx.deployment_target     = '10.9'
   s.watchos.deployment_target = '2.0'

--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -294,19 +294,20 @@ static NSInteger const kCreateBatchSize = 100;
     dispatch_once(&onceToken, ^{
         mappingForClassName = [NSMutableDictionary dictionary];
     });
-
-	NSDictionary *mapping = mappingForClassName[[self className]];
-	if (!mapping) {
-		SEL selector = NSSelectorFromString(@"JSONInboundMappingDictionary");
-		if ([self respondsToSelector:selector]) {
-			mapping = MCValueFromInvocation(self, selector);
-		}
-		else {
-			mapping = [self mc_defaultInboundMapping];
-		}
-		mappingForClassName[[self className]] = mapping;
-	}
-	return mapping;
+    @synchronized(mappingForClassName) {
+        NSDictionary *mapping = mappingForClassName[[self className]];
+        if (!mapping) {
+            SEL selector = NSSelectorFromString(@"JSONInboundMappingDictionary");
+            if ([self respondsToSelector:selector]) {
+                mapping = MCValueFromInvocation(self, selector);
+            }
+            else {
+                mapping = [self mc_defaultInboundMapping];
+            }
+            mappingForClassName[[self className]] = mapping;
+        }
+        return mapping;
+    }
 }
 
 + (NSDictionary *)mc_outboundMapping {
@@ -316,18 +317,20 @@ static NSInteger const kCreateBatchSize = 100;
         mappingForClassName = [NSMutableDictionary dictionary];
     });
 
-	NSDictionary *mapping = mappingForClassName[[self className]];
-	if (!mapping) {
-		SEL selector = NSSelectorFromString(@"JSONOutboundMappingDictionary");
-		if ([self respondsToSelector:selector]) {
-			mapping = MCValueFromInvocation(self, selector);
-		}
-		else {
-			mapping = [self mc_defaultOutboundMapping];
-		}
-		mappingForClassName[[self className]] = mapping;
-	}
-	return mapping;
+    @synchronized(mappingForClassName) {
+        NSDictionary *mapping = mappingForClassName[[self className]];
+        if (!mapping) {
+            SEL selector = NSSelectorFromString(@"JSONOutboundMappingDictionary");
+            if ([self respondsToSelector:selector]) {
+                mapping = MCValueFromInvocation(self, selector);
+            }
+            else {
+                mapping = [self mc_defaultOutboundMapping];
+            }
+            mappingForClassName[[self className]] = mapping;
+        }
+        return mapping;
+    }
 }
 
 + (RLMProperty *)mc_propertyForPropertyKey:(NSString *)key {
@@ -349,12 +352,14 @@ static NSInteger const kCreateBatchSize = 100;
             set = [NSCharacterSet characterSetWithCharactersInString:@"\"<"];
         });
 
-		NSString *string;
-		NSScanner *scanner = [NSScanner scannerWithString:attributes];
-		scanner.charactersToBeSkipped = set;
-		[scanner scanUpToCharactersFromSet:set intoString:NULL];
-		[scanner scanUpToCharactersFromSet:set intoString:&string];
-		return NSClassFromString(string);
+        @synchronized(set) {
+            NSString *string;
+            NSScanner *scanner = [NSScanner scannerWithString:attributes];
+            scanner.charactersToBeSkipped = set;
+            [scanner scanUpToCharactersFromSet:set intoString:NULL];
+            [scanner scanUpToCharactersFromSet:set intoString:&string];
+            return NSClassFromString(string);
+        }
 	}
 	return nil;
 }


### PR DESCRIPTION
We've been getting quite a lot of (usually not the same crash group be different related to one another) crashes related to this library parsing huge chunk of jsons
<img width="1331" alt="screen shot 2016-01-06 at 08 56 04" src="https://cloud.githubusercontent.com/assets/3721061/12137275/b746b4c8-b457-11e5-9363-d4c1c9255be6.png">
After some time of investigation we've found that it's related to multiple threads accessing/modifying the same static dictionaries (as they are not tread-safe). So I have added mutex-lock for those dictionaries and apparently it solved the problem.
