### PR TITLE
Realm CocoaPods dependency removed from Podspec

### DIFF
--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -2,4 +2,5 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '7.0'
 
 pod 'AFNetworking'
+pod 'Realm', '~> 0.97'
 pod 'Realm+JSON', :path => '../'

--- a/Realm+JSON.podspec
+++ b/Realm+JSON.podspec
@@ -16,6 +16,4 @@ Pod::Spec.new do |s|
   }
   s.source_files = 'Realm+JSON/*.{h,m}'
   s.public_header_files = 'Realm+JSON/*.h'
-
-  s.dependency 'Realm', '~> 0.95'
 end


### PR DESCRIPTION
Hi Matthew,

I've removed the dependency of Realm from the Podspec because I think how to install Realm should not be imposed to users. E.g. Realm is currently not working properly with CocoaPods 1.0, so we'll need to install it using dynamic frameworks. However, we'd like to keep installing Realm-JSON through CocoaPods.

Hope this makes sense.