### PR TITLE
Keep null values from the inbound JSON on mapping to Realm

### DIFF
--- a/Realm+JSON/RLMObject+JSON.m
+++ b/Realm+JSON/RLMObject+JSON.m
@@ -166,6 +166,11 @@ static NSInteger const kCreateBatchSize = 100;
 		id value = [dictionary valueForKeyPath:dictionaryKeyPath];
 
 		if (value) {
+			if ([value isEqual:[NSNull null]]) {
+				[result setValue:value forKeyPath:objectKeyPath];
+				continue;
+			}
+
 			Class propertyClass = [[self class] mc_classForPropertyKey:objectKeyPath];
 
 			NSValueTransformer *transformer = [[self class] mc_transformerForPropertyKey:objectKeyPath];


### PR DESCRIPTION
Hi Matthew,

This is the same as https://github.com/matthewcheok/Realm-JSON/pull/73, but in the other direction.

Otherwise null properties (at least those with a value transformer) won't never be updated.